### PR TITLE
Add testing-library linter and update tests

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -14,7 +14,8 @@ module.exports = {
   },
   extends: [
     "plugin:react/recommended",
-    "plugin:@typescript-eslint/recommended"
+    "plugin:@typescript-eslint/recommended",
+    "plugin:testing-library/react"
   ],
   rules: {},
 };

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "canvas": "^2.9.1",
     "eslint": "^7.27.0",
     "eslint-plugin-react": "^7.24.0",
+    "eslint-plugin-testing-library": "^5.5.1",
     "firebase-tools": "^11.2.2",
     "husky": "^7.0.4",
     "jsdom": "^19.0.0",

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -51,7 +51,7 @@ describe(App, () => {
     )
 
     expect(screen.queryByText('Login')).not.toBeInTheDocument()
-    expect(screen.queryByText('Nothing to see here')).toBeInTheDocument()
+    expect(screen.getByText('Nothing to see here')).toBeInTheDocument()
   })
 
   describe('LayoutsWithNavbar', () => {

--- a/src/Auth/LogIn/Form/Form.test.tsx
+++ b/src/Auth/LogIn/Form/Form.test.tsx
@@ -24,20 +24,20 @@ describe(Form, () => {
   })
 
   describe('when sign in is loading', () => {
-    it('should show a spinner on login button', async () => {
+    it('should show a spinner on login button', () => {
       render(<Form {...props} loading={true} />)
 
-      const loginButton = await screen.getByRole('button', { name: '' })
+      const loginButton = screen.getByRole('button', { name: '' })
 
       expect(within(loginButton).getByRole('progressbar')).toBeInTheDocument()
     })
   })
 
   describe('when sign in fails', () => {
-    it('should show an incorrect details message', async () => {
+    it('should show an incorrect details message', () => {
       render(<Form {...props} error={{} as AuthError} />)
 
-      expect(await screen.getByText('Incorrect email or password')).toBeInTheDocument()
+      expect(screen.getByText('Incorrect email or password')).toBeInTheDocument()
     })
   })
 })

--- a/src/Auth/LogIn/LogIn.test.tsx
+++ b/src/Auth/LogIn/LogIn.test.tsx
@@ -17,23 +17,27 @@ describe(LogIn, () => {
     beforeEach(() => {
       const mockSignInWithEmailAndPassword = jest.fn()
       mockSignIn.mockReturnValue([mockSignInWithEmailAndPassword, undefined, false, undefined])
+    })
 
+    const setup = () =>
       render(
         <MemoryRouter>
           <LogIn />
         </MemoryRouter>,
       )
-    })
 
     it('should contain a banner', () => {
+      setup()
       expect(screen.getByRole('banner')).toBeInTheDocument()
     })
 
     it('should contain a form', () => {
+      setup()
       expect(screen.getByRole('form')).toBeInTheDocument()
     })
 
     it('should contain a footer section', () => {
+      setup()
       expect(screen.getByRole('contentinfo')).toBeInTheDocument()
     })
   })

--- a/src/Auth/RequireAuth/RequireAuth.test.tsx
+++ b/src/Auth/RequireAuth/RequireAuth.test.tsx
@@ -31,7 +31,7 @@ describe(RequireAuth, () => {
       </MemoryRouter>,
     )
 
-    expect(screen.queryByText(homeText)).toBeInTheDocument()
+    expect(screen.getByText(homeText)).toBeInTheDocument()
   })
 
   it('should save location if no user', () => {
@@ -55,7 +55,7 @@ describe(RequireAuth, () => {
       </MemoryRouter>,
     )
 
-    expect(screen.queryByText('Previous location: /protected')).toBeInTheDocument()
+    expect(screen.getByText('Previous location: /protected')).toBeInTheDocument()
   })
 
   it('should go to route if there is a user', () => {

--- a/src/components/Dashboard/ActionToolbar/ActionToolbar.test.assertion.tsx
+++ b/src/components/Dashboard/ActionToolbar/ActionToolbar.test.assertion.tsx
@@ -3,9 +3,9 @@ import { Screen } from '@testing-library/react'
 export const actionToolbarPresent = (screen: Screen, present = true): void => {
   present
     ? expect(screen.getByRole('button', { name: 'undo' })).toBeInTheDocument()
-    : expect(screen.getByRole('button', { name: 'undo' })).not.toBeInTheDocument()
+    : expect(screen.queryByRole('button', { name: 'undo' })).not.toBeInTheDocument()
 
   present
     ? expect(screen.getByRole('button', { name: 'clear' })).toBeInTheDocument()
-    : expect(screen.getByRole('button', { name: 'clear' })).not.toBeInTheDocument()
+    : expect(screen.queryByRole('button', { name: 'clear' })).not.toBeInTheDocument()
 }

--- a/src/components/Dashboard/Dashboard.test.tsx
+++ b/src/components/Dashboard/Dashboard.test.tsx
@@ -1,13 +1,19 @@
-import { render } from '@testing-library/react'
+import { render, screen } from '@testing-library/react'
 import React from 'react'
 import { BrowserRouter } from 'react-router-dom'
 import { Dashboard } from './Dashboard'
 
 describe('Dashboard', () => {
   it('should shown a canvas', () => {
-    render(<BrowserRouter><Dashboard /></BrowserRouter>)
-    const myCanvas: HTMLCollectionOf<HTMLCanvasElement> = document.getElementsByTagName('canvas');
-    const firstCanvas = myCanvas.item(0)
-    expect(firstCanvas).toBeInTheDocument()
+    render(
+      <BrowserRouter>
+        <Dashboard />
+      </BrowserRouter>,
+    )
+
+    const canvasTagMatcher = (_content: string, element: Element | null) => element?.tagName.toLowerCase() === 'canvas'
+
+    const myCanvas = screen.getAllByText(canvasTagMatcher)
+    expect(myCanvas.length).toBeGreaterThan(0)
   })
 })

--- a/src/components/Dashboard/ImageToolbar/ImageToolbar.test.assertion.tsx
+++ b/src/components/Dashboard/ImageToolbar/ImageToolbar.test.assertion.tsx
@@ -3,13 +3,13 @@ import { Screen } from '@testing-library/react'
 export const imageToolbarPresent = (screen: Screen, present = true): void => {
   present
     ? expect(screen.getByRole('button', { name: 'Invalid' })).toBeInTheDocument()
-    : expect(screen.getByRole('button', { name: 'Invalid' })).not.toBeInTheDocument()
+    : expect(screen.queryByRole('button', { name: 'Invalid' })).not.toBeInTheDocument()
 
   present
     ? expect(screen.getByRole('button', { name: 'Skip' })).toBeInTheDocument()
-    : expect(screen.getByRole('button', { name: 'Skip' })).not.toBeInTheDocument()
+    : expect(screen.queryByRole('button', { name: 'Skip' })).not.toBeInTheDocument()
 
   present
     ? expect(screen.getByRole('button', { name: 'Save' })).toBeInTheDocument()
-    : expect(screen.getByRole('button', { name: 'Save' })).not.toBeInTheDocument()
+    : expect(screen.queryByRole('button', { name: 'Save' })).not.toBeInTheDocument()
 }

--- a/src/components/LoadingButton/LoadingButton.test.tsx
+++ b/src/components/LoadingButton/LoadingButton.test.tsx
@@ -46,7 +46,7 @@ describe(LoadingButton, () => {
 
       const loginButton = screen.getByRole('button')
 
-      expect(within(loginButton).queryByRole('progressbar')).toBeInTheDocument()
+      expect(within(loginButton).getByRole('progressbar')).toBeInTheDocument()
     })
 
     it('should disable button', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2705,6 +2705,14 @@
     "@typescript-eslint/types" "5.10.1"
     "@typescript-eslint/visitor-keys" "5.10.1"
 
+"@typescript-eslint/scope-manager@5.30.6":
+  version "5.30.6"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-5.30.6.tgz#ce1b49ff5ce47f55518d63dbe8fc9181ddbd1a33"
+  integrity sha512-Hkq5PhLgtVoW1obkqYH0i4iELctEKixkhWLPTYs55doGUKCASvkjOXOd/pisVeLdO24ZX9D6yymJ/twqpJiG3g==
+  dependencies:
+    "@typescript-eslint/types" "5.30.6"
+    "@typescript-eslint/visitor-keys" "5.30.6"
+
 "@typescript-eslint/type-utils@5.10.1":
   version "5.10.1"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/type-utils/-/type-utils-5.10.1.tgz#5e526c00142585e40ab1503e83f1ff608c367405"
@@ -2723,6 +2731,11 @@
   version "5.10.1"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-5.10.1.tgz#dca9bd4cb8c067fc85304a31f38ec4766ba2d1ea"
   integrity sha512-ZvxQ2QMy49bIIBpTqFiOenucqUyjTQ0WNLhBM6X1fh1NNlYAC6Kxsx8bRTY3jdYsYg44a0Z/uEgQkohbR0H87Q==
+
+"@typescript-eslint/types@5.30.6":
+  version "5.30.6"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-5.30.6.tgz#86369d0a7af8c67024115ac1da3e8fb2d38907e1"
+  integrity sha512-HdnP8HioL1F7CwVmT4RaaMX57RrfqsOMclZc08wGMiDYJBsLGBM7JwXM4cZJmbWLzIR/pXg1kkrBBVpxTOwfUg==
 
 "@typescript-eslint/typescript-estree@4.33.0":
   version "4.33.0"
@@ -2750,6 +2763,19 @@
     semver "^7.3.5"
     tsutils "^3.21.0"
 
+"@typescript-eslint/typescript-estree@5.30.6":
+  version "5.30.6"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-5.30.6.tgz#a84a0d6a486f9b54042da1de3d671a2c9f14484e"
+  integrity sha512-Z7TgPoeYUm06smfEfYF0RBkpF8csMyVnqQbLYiGgmUSTaSXTP57bt8f0UFXstbGxKIreTwQCujtaH0LY9w9B+A==
+  dependencies:
+    "@typescript-eslint/types" "5.30.6"
+    "@typescript-eslint/visitor-keys" "5.30.6"
+    debug "^4.3.4"
+    globby "^11.1.0"
+    is-glob "^4.0.3"
+    semver "^7.3.7"
+    tsutils "^3.21.0"
+
 "@typescript-eslint/utils@5.10.1":
   version "5.10.1"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/utils/-/utils-5.10.1.tgz#fa682a33af47080ba2c4368ee0ad2128213a1196"
@@ -2759,6 +2785,18 @@
     "@typescript-eslint/scope-manager" "5.10.1"
     "@typescript-eslint/types" "5.10.1"
     "@typescript-eslint/typescript-estree" "5.10.1"
+    eslint-scope "^5.1.1"
+    eslint-utils "^3.0.0"
+
+"@typescript-eslint/utils@^5.13.0":
+  version "5.30.6"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/utils/-/utils-5.30.6.tgz#1de2da14f678e7d187daa6f2e4cdb558ed0609dc"
+  integrity sha512-xFBLc/esUbLOJLk9jKv0E9gD/OH966M40aY9jJ8GiqpSkP2xOV908cokJqqhVd85WoIvHVHYXxSFE4cCSDzVvA==
+  dependencies:
+    "@types/json-schema" "^7.0.9"
+    "@typescript-eslint/scope-manager" "5.30.6"
+    "@typescript-eslint/types" "5.30.6"
+    "@typescript-eslint/typescript-estree" "5.30.6"
     eslint-scope "^5.1.1"
     eslint-utils "^3.0.0"
 
@@ -2777,6 +2815,14 @@
   dependencies:
     "@typescript-eslint/types" "5.10.1"
     eslint-visitor-keys "^3.0.0"
+
+"@typescript-eslint/visitor-keys@5.30.6":
+  version "5.30.6"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-5.30.6.tgz#94dd10bb481c8083378d24de1742a14b38a2678c"
+  integrity sha512-41OiCjdL2mCaSDi2SvYbzFLlqqlm5v1ZW9Ym55wXKL/Rx6OOB1IbuFGo71Fj6Xy90gJDFTlgOS+vbmtGHPTQQA==
+  dependencies:
+    "@typescript-eslint/types" "5.30.6"
+    eslint-visitor-keys "^3.3.0"
 
 "@webassemblyjs/ast@1.11.1":
   version "1.11.1"
@@ -4810,7 +4856,7 @@ debug@^3.1.1, debug@^3.2.7:
   dependencies:
     ms "^2.1.1"
 
-debug@^4.3.3:
+debug@^4.3.3, debug@^4.3.4:
   version "4.3.4"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.4.tgz#1319f6579357f2338d3337d2cdd4914bb5dcc865"
   integrity sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==
@@ -5568,6 +5614,13 @@ eslint-plugin-testing-library@^5.0.1:
   dependencies:
     "@typescript-eslint/experimental-utils" "^5.9.0"
 
+eslint-plugin-testing-library@^5.5.1:
+  version "5.5.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-testing-library/-/eslint-plugin-testing-library-5.5.1.tgz#6fe602f9082a421b471bbae8aed692e26fe981b3"
+  integrity sha512-plLEkkbAKBjPxsLj7x4jNapcHAg2ernkQlKKrN2I8NrQwPISZHyCUNvg5Hv3EDqOQReToQb5bnqXYbkijJPE/g==
+  dependencies:
+    "@typescript-eslint/utils" "^5.13.0"
+
 eslint-scope@5.1.1, eslint-scope@^5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-5.1.1.tgz#e786e59a66cb92b3f6c1fb0d508aab174848f48c"
@@ -5612,6 +5665,11 @@ eslint-visitor-keys@^3.0.0, eslint-visitor-keys@^3.1.0, eslint-visitor-keys@^3.2
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-3.2.0.tgz#6fbb166a6798ee5991358bc2daa1ba76cc1254a1"
   integrity sha512-IOzT0X126zn7ALX0dwFiUQEdsfzrm4+ISsQS8nukaJXwEyYKRSnEIIDULYg1mCtGp7UUXgfGl7BIolXREQK+XQ==
+
+eslint-visitor-keys@^3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz#f6480fa6b1f30efe2d1968aa8ac745b862469826"
+  integrity sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==
 
 eslint-webpack-plugin@^3.1.1:
   version "3.1.1"
@@ -6672,7 +6730,7 @@ globals@^13.6.0, globals@^13.9.0:
   dependencies:
     type-fest "^0.20.2"
 
-globby@^11.0.1, globby@^11.0.3, globby@^11.0.4:
+globby@^11.0.1, globby@^11.0.3, globby@^11.0.4, globby@^11.1.0:
   version "11.1.0"
   resolved "https://registry.yarnpkg.com/globby/-/globby-11.1.0.tgz#bd4be98bb042f83d796f7e3811991fbe82a0d34b"
   integrity sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==


### PR DESCRIPTION
Considering that some tests were not in accordance with the recommended use of the [react-testing-library](https://testing-library.com/docs/react-testing-library/intro/).
This pull request changes:
- add the [eslint-plugin-testing-library](https://github.com/testing-library/eslint-plugin-testing-library) to check the tests about such errors/warnings during linting step (pre-commit)
- update the tests to comply with the recommended rules

Please note that a new dependency is being added to the project, so it is necessary to run:
```bash
yarn install
```
Reference:\
https://kentcdodds.com/blog/common-mistakes-with-react-testing-library \
https://testing-library.com/docs/queries/about#priority