### PR TITLE
Add No Images to Label message

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "web-vitals": "^1.1.2"
   },
   "devDependencies": {
+    "@material-ui/lab": "^4.0.0-alpha.61",
     "@testing-library/react-hooks": "^8.0.1",
     "@typescript-eslint/eslint-plugin": "^5.31.0",
     "@typescript-eslint/parser": "^5.31.0",

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -7,8 +7,8 @@ import { User } from '@firebase/auth/dist/auth-public'
 import { mocked } from 'jest-mock'
 import { assertNavbarPresent } from './components/Navbar/Navbar.test.assertion'
 import { assertLogInPresent } from './Auth/LogIn/LogIn.test.assertion'
-import { actionToolbarPresent } from './components/Dashboard/ActionToolbar/ActionToolbar.test.assertion'
-import { imageToolbarPresent } from './components/Dashboard/ImageToolbar/ImageToolbar.test.assertion'
+import { assertActionToolbarPresent } from './components/Dashboard/ActionToolbar/ActionToolbar.test.assertion'
+import { assertImageToolbarPresent } from './components/Dashboard/ImageToolbar/ImageToolbar.test.assertion'
 import { SnackbarProvider } from 'notistack'
 
 jest.mock('react-firebase-hooks/auth')
@@ -89,8 +89,8 @@ describe(App, () => {
         </MemoryRouter>,
       )
 
-      actionToolbarPresent(screen, true)
-      imageToolbarPresent(screen, true)
+      assertActionToolbarPresent()
+      assertImageToolbarPresent()
       expect(screen.queryByText('Login')).not.toBeInTheDocument()
 
       assertNavbarPresent(screen)

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -7,9 +7,8 @@ import { User } from '@firebase/auth/dist/auth-public'
 import { mocked } from 'jest-mock'
 import { assertNavbarPresent } from './components/Navbar/Navbar.test.assertion'
 import { assertLogInPresent } from './Auth/LogIn/LogIn.test.assertion'
-import { assertActionToolbarPresent } from './components/Dashboard/ActionToolbar/ActionToolbar.test.assertion'
-import { assertImageToolbarPresent } from './components/Dashboard/ImageToolbar/ImageToolbar.test.assertion'
 import { SnackbarProvider } from 'notistack'
+import { assertDashboardPresent } from './components/Dashboard/Dashboard.test.assertion'
 
 jest.mock('react-firebase-hooks/auth')
 jest.mock('react-canvas-draw')
@@ -30,7 +29,7 @@ describe(App, () => {
       </MemoryRouter>,
     )
 
-    assertLogInPresent(screen)
+    assertLogInPresent()
   })
 
   it('should redirect to login page when not authenticated', async () => {
@@ -40,7 +39,7 @@ describe(App, () => {
       </MemoryRouter>,
     )
 
-    assertLogInPresent(screen)
+    assertLogInPresent()
     expect(screen.queryByText('Dashboard')).not.toBeInTheDocument()
   })
 
@@ -63,7 +62,7 @@ describe(App, () => {
         </MemoryRouter>,
       )
 
-      assertNavbarPresent(screen)
+      assertNavbarPresent()
     })
 
     it('should not show the navbar on 404', () => {
@@ -73,7 +72,7 @@ describe(App, () => {
         </MemoryRouter>,
       )
 
-      assertNavbarPresent(screen, false)
+      assertNavbarPresent(false)
     })
   })
 
@@ -89,11 +88,10 @@ describe(App, () => {
         </MemoryRouter>,
       )
 
-      assertActionToolbarPresent()
-      assertImageToolbarPresent()
-      expect(screen.queryByText('Login')).not.toBeInTheDocument()
+      assertDashboardPresent()
+      assertNavbarPresent()
 
-      assertNavbarPresent(screen)
+      expect(screen.queryByText('Login')).not.toBeInTheDocument()
     })
   })
 })

--- a/src/Auth/LogIn/LogIn.test.assertion.tsx
+++ b/src/Auth/LogIn/LogIn.test.assertion.tsx
@@ -1,6 +1,6 @@
-import { Screen } from '@testing-library/react'
+import { screen } from '@testing-library/react'
 
-export const assertLogInPresent = (screen: Screen, present = true): void => {
+export const assertLogInPresent = (present = true): void => {
   present
     ? expect(screen.getByRole('img', { name: 'login-header' })).toBeInTheDocument()
     : expect(screen.queryByRole('img', { name: 'login-header' })).not.toBeInTheDocument()

--- a/src/components/Dashboard/ActionToolbar/ActionToolbar.test.assertion.tsx
+++ b/src/components/Dashboard/ActionToolbar/ActionToolbar.test.assertion.tsx
@@ -1,6 +1,6 @@
-import { Screen } from '@testing-library/react'
+import { screen } from '@testing-library/react'
 
-export const actionToolbarPresent = (screen: Screen, present = true): void => {
+export const assertActionToolbarPresent = (present = true): void => {
   present
     ? expect(screen.getByRole('button', { name: 'undo' })).toBeInTheDocument()
     : expect(screen.queryByRole('button', { name: 'undo' })).not.toBeInTheDocument()

--- a/src/components/Dashboard/Dashboard.module.css
+++ b/src/components/Dashboard/Dashboard.module.css
@@ -1,4 +1,4 @@
-.container {
+.dashboardContainer {
   display: flex;
   flex-direction: column;
   align-items: center;

--- a/src/components/Dashboard/Dashboard.test.assertion.tsx
+++ b/src/components/Dashboard/Dashboard.test.assertion.tsx
@@ -1,0 +1,8 @@
+import { screen } from '@testing-library/react'
+
+export const assertCanvasPresent = (present = true): void => {
+  const canvasTagMatcher = (_content: string, element: Element | null) => element?.tagName.toLowerCase() === 'canvas'
+  const canvasElements = screen.getAllByText(canvasTagMatcher)
+
+  present ? expect(canvasElements.length).toBeGreaterThan(0) : expect(canvasElements.length).toBe(0)
+}

--- a/src/components/Dashboard/Dashboard.test.assertion.tsx
+++ b/src/components/Dashboard/Dashboard.test.assertion.tsx
@@ -1,8 +1,23 @@
 import { screen } from '@testing-library/react'
 
+export const assertDashboardPresent = (present = true): void => {
+  const dashboardMatcher = (_content: string, element: Element | null) => element?.className === 'dashboardContainer'
+
+  present
+    ? expect(screen.getAllByText(dashboardMatcher).length).toBeGreaterThan(0)
+    : expect(screen.queryAllByText(dashboardMatcher).length).toBe(0)
+}
+
 export const assertCanvasPresent = (present = true): void => {
   const canvasTagMatcher = (_content: string, element: Element | null) => element?.tagName.toLowerCase() === 'canvas'
-  const canvasElements = screen.getAllByText(canvasTagMatcher)
 
-  present ? expect(canvasElements.length).toBeGreaterThan(0) : expect(canvasElements.length).toBe(0)
+  present
+    ? expect(screen.getAllByText(canvasTagMatcher).length).toBeGreaterThan(0)
+    : expect(screen.queryAllByText(canvasTagMatcher).length).toBe(0)
+}
+
+export const assertProgressBarPresent = (present = true): void => {
+  present
+    ? expect(screen.getByLabelText('Progress Bar')).toBeVisible()
+    : expect(screen.queryByLabelText('Progress Bar')).not.toBeVisible()
 }

--- a/src/components/Dashboard/Dashboard.test.tsx
+++ b/src/components/Dashboard/Dashboard.test.tsx
@@ -64,14 +64,19 @@ describe('Dashboard', () => {
       assertNoPendingImagePresent(false)
     })
 
-    it('should render the progressbar and not the content whilst fetching the data', () => {
-      renderWithExistingImage()
+    it('should render the progressbar and not the content whilst fetching the data', async () => {
+      renderWithNoImageToLabel()
 
       assertProgressBarPresent()
       assertNoPendingImagePresent(false)
       assertActionToolbarPresent(false)
       assertCanvasPresent(false)
       assertImageToolbarPresent(false)
+
+      // Wait for the fetch to complete and check the progressbar is gone
+      await waitFor(() => {
+        assertProgressBarPresent(false)
+      })
     })
   })
 
@@ -120,17 +125,24 @@ describe('Dashboard', () => {
         const saveButton = await screen.findByRole('button', { name: 'Save' })
 
         // Check that the buttons are ENABLED
-        expect(skipButton).not.toHaveAttribute('disabled')
-        expect(saveButton).not.toHaveAttribute('disabled')
-        expect(invalidButton).not.toHaveAttribute('disabled')
+        expect(skipButton).toBeEnabled()
+        expect(invalidButton).toBeEnabled()
+        expect(saveButton).toBeEnabled()
 
         // Start skipping the image
         fireEvent.click(skipButton)
 
         // Check that the buttons are DISABLED
-        expect(skipButton).toHaveAttribute('disabled')
-        expect(saveButton).toHaveAttribute('disabled')
-        expect(invalidButton).toHaveAttribute('disabled')
+        expect(skipButton).toBeDisabled()
+        expect(invalidButton).toBeDisabled()
+        expect(saveButton).toBeDisabled()
+
+        // Wait for the skip image to complete and check that the buttons are ENABLED again
+        await waitFor(() => {
+          expect(screen.getByRole('button', { name: 'Skip' })).toBeEnabled()
+        })
+        expect(screen.getByRole('button', { name: 'Invalid' })).toBeEnabled()
+        expect(screen.getByRole('button', { name: 'Save' })).toBeEnabled()
       })
 
       it('should fetch the next image to label when skip image succeed', async () => {
@@ -189,22 +201,29 @@ describe('Dashboard', () => {
       it('should disable the buttons while marking the image as invalid', async () => {
         renderWithExistingImage()
 
-        const skipButton = await screen.findByRole('button', { name: 'Skip' })
         const invalidButton = await screen.findByRole('button', { name: 'Invalid' })
+        const skipButton = await screen.findByRole('button', { name: 'Skip' })
         const saveButton = await screen.findByRole('button', { name: 'Save' })
 
-        // Check that the buttons are DISABLED
-        expect(invalidButton).not.toHaveAttribute('disabled')
-        expect(skipButton).not.toHaveAttribute('disabled')
-        expect(saveButton).not.toHaveAttribute('disabled')
+        // Check that the buttons are ENABLED
+        expect(invalidButton).toBeEnabled()
+        expect(skipButton).toBeEnabled()
+        expect(saveButton).toBeEnabled()
 
-        // Start marking the image as invalid
-        userEvent.click(invalidButton)
+        // Start marking the image invalid
+        fireEvent.click(invalidButton)
 
         // Check that the buttons are DISABLED
-        expect(invalidButton).toHaveAttribute('disabled')
-        expect(skipButton).toHaveAttribute('disabled')
-        expect(saveButton).toHaveAttribute('disabled')
+        expect(invalidButton).toBeDisabled()
+        expect(skipButton).toBeDisabled()
+        expect(saveButton).toBeDisabled()
+
+        // Wait for the skip image to complete and check that the buttons are ENABLED again
+        await waitFor(() => {
+          expect(screen.getByRole('button', { name: 'Invalid' })).toBeEnabled()
+        })
+        expect(screen.getByRole('button', { name: 'Skip' })).toBeEnabled()
+        expect(screen.getByRole('button', { name: 'Save' })).toBeEnabled()
       })
 
       it('should fetch the next image to label when markImageInvalid succeed', async () => {

--- a/src/components/Dashboard/Dashboard.tsx
+++ b/src/components/Dashboard/Dashboard.tsx
@@ -10,6 +10,7 @@ import Image from '../../model/image'
 import useNotification from '../../services/Notification/NotificationService'
 import { Backdrop, CircularProgress } from '@material-ui/core'
 import BlankImage from '../../assets/img/blank.png'
+import { NoPendingImage } from './NoPendingImage/NoPendingImage'
 
 type SelectedImageType = {
   location: string
@@ -26,7 +27,7 @@ const selectedImageInitialState: SelectedImageType = {
 }
 
 export const Dashboard = (): ReactElement => {
-  const [imageState, setImageState] = useState<Image>()
+  const [imageState, setImageState] = useState<Image | null>()
   const [isLoading, setIsLoading] = useState(false)
   const [selectedImage, setSelectedImage] = useState(selectedImageInitialState)
   const location = useLocation()
@@ -137,30 +138,39 @@ export const Dashboard = (): ReactElement => {
   const isImageLoaded = imageState && selectedImage != selectedImageInitialState
 
   return (
-    <div className={styles.container}>
-      <div className={styles.canvasContainer} style={{ opacity: isLoading ? '0.5' : '1' }}>
-        <ActionToolbar clearAction={clearCanvas} undoAction={undoAction} />
-        <CanvasDraw
-          lazyRadius={0}
-          ref={(canvasDraw) => (canvas = canvasDraw)}
-          canvasWidth={selectedImage.width}
-          canvasHeight={selectedImage.height}
-          enablePanAndZoom={true}
-          clampLinesToDocument={true}
-          imgSrc={selectedImage.url}
-          className={styles.canvas}
-          disabled={isLoading || !isImageLoaded}
-        />
+    <>
+      <div className={styles.dashboardContainer}>
+        {!isLoading && imageState === null && <NoPendingImage onCheckAgain={fetchImage} />}
+
+        {isImageLoaded && (
+          <>
+            <div className={styles.canvasContainer}>
+              <ActionToolbar clearAction={clearCanvas} undoAction={undoAction} />
+              <CanvasDraw
+                lazyRadius={0}
+                ref={(canvasDraw) => (canvas = canvasDraw)}
+                canvasWidth={selectedImage.width}
+                canvasHeight={selectedImage.height}
+                enablePanAndZoom={true}
+                clampLinesToDocument={true}
+                imgSrc={selectedImage.url}
+                className={styles.canvas}
+                disabled={isLoading}
+              />
+            </div>
+            <ImageToolbar
+              saveAction={saveAction}
+              invalidAction={invalidAction}
+              skipAction={skipAction}
+              disabled={isLoading}
+            />
+          </>
+        )}
       </div>
-      <ImageToolbar
-        saveAction={saveAction}
-        invalidAction={invalidAction}
-        skipAction={skipAction}
-        disabled={isLoading || !isImageLoaded}
-      />
+
       <Backdrop open={isLoading} className={styles.progressBackdrop} aria-label="Progress Bar">
         <CircularProgress />
       </Backdrop>
-    </div>
+    </>
   )
 }

--- a/src/components/Dashboard/ImageToolbar/ImageToolbar.test.assertion.tsx
+++ b/src/components/Dashboard/ImageToolbar/ImageToolbar.test.assertion.tsx
@@ -1,6 +1,6 @@
-import { Screen } from '@testing-library/react'
+import { screen } from '@testing-library/react'
 
-export const imageToolbarPresent = (screen: Screen, present = true): void => {
+export const assertImageToolbarPresent = (present = true): void => {
   present
     ? expect(screen.getByRole('button', { name: 'Invalid' })).toBeInTheDocument()
     : expect(screen.queryByRole('button', { name: 'Invalid' })).not.toBeInTheDocument()

--- a/src/components/Dashboard/ImageToolbar/ImageToolbar.test.tsx
+++ b/src/components/Dashboard/ImageToolbar/ImageToolbar.test.tsx
@@ -46,9 +46,9 @@ describe(ImageToolbar, () => {
     const saveButton = screen.getByRole('button', { name: 'Save' })
     const skipButton = screen.getByRole('button', { name: 'Skip' })
 
-    expect(invalidButton).toHaveAttribute('disabled')
-    expect(saveButton).toHaveAttribute('disabled')
-    expect(skipButton).toHaveAttribute('disabled')
+    expect(invalidButton).toBeDisabled()
+    expect(saveButton).toBeDisabled()
+    expect(skipButton).toBeDisabled()
   })
 
   it('should not disable the buttons when disabled is false', () => {
@@ -60,9 +60,9 @@ describe(ImageToolbar, () => {
     const saveButton = screen.getByRole('button', { name: 'Save' })
     const skipButton = screen.getByRole('button', { name: 'Skip' })
 
-    expect(invalidButton).not.toHaveAttribute('disabled')
-    expect(saveButton).not.toHaveAttribute('disabled')
-    expect(skipButton).not.toHaveAttribute('disabled')
+    expect(invalidButton).toBeEnabled()
+    expect(saveButton).toBeEnabled()
+    expect(skipButton).toBeEnabled()
   })
 
   it('should not disable the buttons when disabled is not specified', () => {
@@ -72,8 +72,8 @@ describe(ImageToolbar, () => {
     const saveButton = screen.getByRole('button', { name: 'Save' })
     const skipButton = screen.getByRole('button', { name: 'Skip' })
 
-    expect(invalidButton).not.toHaveAttribute('disabled')
-    expect(saveButton).not.toHaveAttribute('disabled')
-    expect(skipButton).not.toHaveAttribute('disabled')
+    expect(invalidButton).toBeEnabled()
+    expect(saveButton).toBeEnabled()
+    expect(skipButton).toBeEnabled()
   })
 })

--- a/src/components/Dashboard/NoPendingImage/NoPendingImage.module.css
+++ b/src/components/Dashboard/NoPendingImage/NoPendingImage.module.css
@@ -1,17 +1,18 @@
-.box {
+.container {
   border-radius: 3px;
-  width: 400px;
-  padding: 5px 10px 20px 10px;
+  width: 25rem;
+  padding: 0.5rem 1rem 2rem 1rem;
   background-color: #f3eff8;
+  align-self: flex-start;
 }
 
 .message {
   border-bottom: 1px solid #dcd6e7;
-  padding-bottom: 15px;
-  padding-left: 10px;
+  padding-bottom: 1rem;
+  padding-left: 0.5rem;
 }
 
 .refreshButton {
-  margin-left: 10px;
-  background-color: white;
+  margin-left: 0.5rem;
+  background-color: white !important;
 }

--- a/src/components/Dashboard/NoPendingImage/NoPendingImage.module.css
+++ b/src/components/Dashboard/NoPendingImage/NoPendingImage.module.css
@@ -1,0 +1,17 @@
+.box {
+  border-radius: 3px;
+  width: 400px;
+  padding: 5px 10px 20px 10px;
+  background-color: #f3eff8;
+}
+
+.message {
+  border-bottom: 1px solid #dcd6e7;
+  padding-bottom: 15px;
+  padding-left: 10px;
+}
+
+.refreshButton {
+  margin-left: 10px;
+  background-color: white;
+}

--- a/src/components/Dashboard/NoPendingImage/NoPendingImage.test.assertion.tsx
+++ b/src/components/Dashboard/NoPendingImage/NoPendingImage.test.assertion.tsx
@@ -1,0 +1,8 @@
+import { screen } from '@testing-library/react'
+import { noPendingImageMessage } from './NoPendingImage'
+
+export const assertNoPendingImagePresent = (present = true): void => {
+  present
+    ? expect(screen.getByText(noPendingImageMessage)).toBeInTheDocument()
+    : expect(screen.queryByText(noPendingImageMessage)).not.toBeInTheDocument()
+}

--- a/src/components/Dashboard/NoPendingImage/NoPendingImage.test.tsx
+++ b/src/components/Dashboard/NoPendingImage/NoPendingImage.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { render, screen } from '@testing-library/react'
 import { NoPendingImage } from './NoPendingImage'
+import userEvent from '@testing-library/user-event'
 
 describe('NoPendingImage', () => {
   it('should render a message', () => {
@@ -13,5 +14,15 @@ describe('NoPendingImage', () => {
     render(<NoPendingImage />)
 
     expect(screen.getByRole('button', { name: 'Check again' })).toBeInTheDocument()
+  })
+
+  it('should trigger the onCheckAgain callback when the refresh button is clicked', () => {
+    const onCheckAgain = jest.fn()
+    render(<NoPendingImage onCheckAgain={onCheckAgain} />)
+
+    const refreshButton = screen.getByRole('button', { name: 'Check again' })
+    userEvent.click(refreshButton)
+
+    expect(onCheckAgain).toHaveBeenCalled()
   })
 })

--- a/src/components/Dashboard/NoPendingImage/NoPendingImage.test.tsx
+++ b/src/components/Dashboard/NoPendingImage/NoPendingImage.test.tsx
@@ -1,0 +1,17 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import { NoPendingImage } from './NoPendingImage'
+
+describe('NoPendingImage', () => {
+  it('should render a message', () => {
+    render(<NoPendingImage />)
+
+    expect(screen.getByText('No image for relabelling was found.')).toBeInTheDocument()
+  })
+
+  it('should render a refresh button', () => {
+    render(<NoPendingImage />)
+
+    expect(screen.getByRole('button', { name: 'Check again' })).toBeInTheDocument()
+  })
+})

--- a/src/components/Dashboard/NoPendingImage/NoPendingImage.tsx
+++ b/src/components/Dashboard/NoPendingImage/NoPendingImage.tsx
@@ -7,10 +7,12 @@ type Props = {
   onCheckAgain?: () => void
 }
 
+export const noPendingImageMessage = 'No image for relabelling was found.'
+
 export const NoPendingImage = ({ onCheckAgain }: Props): ReactElement => {
   return (
     <Box className={styles.container}>
-      <p className={styles.message}>No image for relabelling was found.</p>
+      <p className={styles.message}>{noPendingImageMessage}</p>
       <Button
         variant="outlined"
         color="primary"

--- a/src/components/Dashboard/NoPendingImage/NoPendingImage.tsx
+++ b/src/components/Dashboard/NoPendingImage/NoPendingImage.tsx
@@ -3,7 +3,11 @@ import { Box, Button } from '@material-ui/core'
 import { Autorenew } from '@material-ui/icons'
 import styles from './NoPendingImage.module.css'
 
-export const NoPendingImage = (): ReactElement => {
+type Props = {
+  onCheckAgain?: () => void
+}
+
+export const NoPendingImage = ({ onCheckAgain }: Props): ReactElement => {
   return (
     <Box className={styles.container}>
       <p className={styles.message}>No image for relabelling was found.</p>
@@ -13,6 +17,7 @@ export const NoPendingImage = (): ReactElement => {
         size="small"
         startIcon={<Autorenew />}
         className={styles.refreshButton}
+        onClick={onCheckAgain}
       >
         Check again
       </Button>

--- a/src/components/Dashboard/NoPendingImage/NoPendingImage.tsx
+++ b/src/components/Dashboard/NoPendingImage/NoPendingImage.tsx
@@ -1,0 +1,21 @@
+import React, { ReactElement } from 'react'
+import { Box, Button } from '@material-ui/core'
+import { Autorenew } from '@material-ui/icons'
+import styles from './NoPendingImage.module.css'
+
+export const NoPendingImage = (): ReactElement => {
+  return (
+    <Box className={styles.container}>
+      <p className={styles.message}>No image for relabelling was found.</p>
+      <Button
+        variant="outlined"
+        color="primary"
+        size="small"
+        startIcon={<Autorenew />}
+        className={styles.refreshButton}
+      >
+        Check again
+      </Button>
+    </Box>
+  )
+}

--- a/src/components/Navbar/Navbar.test.assertion.tsx
+++ b/src/components/Navbar/Navbar.test.assertion.tsx
@@ -1,6 +1,6 @@
-import { Screen } from '@testing-library/react'
+import { screen } from '@testing-library/react'
 
-export const assertNavbarPresent = (screen: Screen, present = true): void => {
+export const assertNavbarPresent = (present = true): void => {
   present
     ? expect(screen.getByRole('link', { name: 'aiscope-logo' })).toHaveAttribute('href', 'https://aiscope.net/')
     : expect(screen.queryByRole('link')).not.toBeInTheDocument()

--- a/src/components/Navbar/Navbar.test.tsx
+++ b/src/components/Navbar/Navbar.test.tsx
@@ -19,7 +19,7 @@ describe(Navbar, () => {
   it('should have link back to main aiscope page', () => {
     render(<Navbar />)
 
-    assertNavbarPresent(screen)
+    assertNavbarPresent()
   })
 
   it(' link should display the aiscope logo', () => {

--- a/src/services/ImageRepositoryService.ts
+++ b/src/services/ImageRepositoryService.ts
@@ -15,7 +15,6 @@ export async function uploadImage(
   imageIndex: number,
   maskIndex: number,
 ): Promise<void> {
-  console.log(file)
   const storage = getStorage()
 
   const reference: StorageReference = ref(storage, `${location}/mask_${imageIndex}_${maskIndex}`)

--- a/src/services/ImagesService/ImagesService.test.ts
+++ b/src/services/ImagesService/ImagesService.test.ts
@@ -64,11 +64,12 @@ describe('ImagesService', () => {
 
     it('should call the fetchImageToLabel cloud function and return when there is no image ', async () => {
       const functionCallSpy = jest.spyOn(functions, 'httpsCallable')
-      functionCallSpy.mockReturnValue(() => Promise.resolve({ data: undefined }))
+      functionCallSpy.mockReturnValue(() => Promise.resolve({ data: null }))
 
       const result = await fetchImageToLabel()
 
-      expect(result).toBeUndefined()
+      expect(result).toBeDefined()
+      expect(result).toBeNull()
       expect(functionCallSpy).toHaveBeenCalled()
     })
   })

--- a/src/services/ImagesService/ImagesService.ts
+++ b/src/services/ImagesService/ImagesService.ts
@@ -5,7 +5,7 @@ import { functionsInstance } from '../firebaseService'
 import { SkipImageRequest, SkipImageResponse } from './api/SkipImageApi'
 import { MarkImageInvalidRequest, MarkImageInvalidResponse } from './api/MarkImageInvalidApi'
 
-export async function fetchImageToLabel(): Promise<Image | undefined> {
+export async function fetchImageToLabel(): Promise<Image | null> {
   const fetchImageToLabelFunction = httpsCallable<unknown, Image>(
     functionsInstance,
     CloudFunctions.FETCH_IMAGE_TO_LABEL,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1870,6 +1870,17 @@
   dependencies:
     "@babel/runtime" "^7.4.4"
 
+"@material-ui/lab@^4.0.0-alpha.61":
+  version "4.0.0-alpha.61"
+  resolved "https://registry.yarnpkg.com/@material-ui/lab/-/lab-4.0.0-alpha.61.tgz#9bf8eb389c0c26c15e40933cc114d4ad85e3d978"
+  integrity sha512-rSzm+XKiNUjKegj8bzt5+pygZeckNLOr+IjykH8sYdVk7dE9y2ZuUSofiMV2bJk3qU+JHwexmw+q0RyNZB9ugg==
+  dependencies:
+    "@babel/runtime" "^7.4.4"
+    "@material-ui/utils" "^4.11.3"
+    clsx "^1.0.4"
+    prop-types "^15.7.2"
+    react-is "^16.8.0 || ^17.0.0"
+
 "@material-ui/styles@^4.11.5":
   version "4.11.5"
   resolved "https://registry.yarnpkg.com/@material-ui/styles/-/styles-4.11.5.tgz#19f84457df3aafd956ac863dbe156b1d88e2bbfb"


### PR DESCRIPTION
This PR adds a new component (NoPendingImage) intended to inform the user when all the images are labelled, and no image was returned by `fetchImageToLabel`.\
Includes a button to check again.

![image](https://user-images.githubusercontent.com/15014647/185869217-872a4fd1-709a-4392-a85b-d939f4cef697.png)

Additionally:
- Refactor some test assertions